### PR TITLE
Add cleanup utility and maintenance docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Ignore environment and compiled files
+.env
+__pycache__/
+
+# Ignore generated output
+output/
+temp_sessions/
+
+# LaTeX artifacts
+*.aux
+*.log
+*.out
+*.pdf
+*.tex
+

--- a/README.md
+++ b/README.md
@@ -215,6 +215,15 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [ ] Batch processing
 - [ ] Template customization interface
 - [ ] Export to other formats
+## 🧹 Maintenance
+
+Generated files in `output/` and temporary session data can grow over time.
+Use the `cleanup.py` script to remove files older than a specified number of days.
+
+```bash
+python cleanup.py --days 7
+```
+
 
 ## 📞 Support
 

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Utility script for removing old generated files."""
+import os
+import time
+import argparse
+
+DEFAULT_DIRS = ["output", "temp_sessions"]
+DEFAULT_DAYS = 7
+
+
+def cleanup_dir(path: str, max_age_days: int):
+    """Remove files older than `max_age_days` in `path`."""
+    now = time.time()
+    removed = []
+    if not os.path.exists(path):
+        return removed
+    for name in os.listdir(path):
+        file_path = os.path.join(path, name)
+        if os.path.isfile(file_path):
+            try:
+                if now - os.path.getmtime(file_path) > max_age_days * 86400:
+                    os.remove(file_path)
+                    removed.append(name)
+            except Exception as err:
+                print(f"Could not remove {file_path}: {err}")
+    return removed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clean up generated files")
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=DEFAULT_DAYS,
+        help="Delete files older than this many days",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=DEFAULT_DIRS,
+        help="Directories to clean",
+    )
+    args = parser.parse_args()
+
+    for path in args.paths:
+        removed = cleanup_dir(path, args.days)
+        if removed:
+            print(f"Removed {len(removed)} files from {path}")
+        else:
+            print(f"No old files found in {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script `cleanup.py` to purge old generated files
- ignore outputs and session files via `.gitignore`
- document maintenance step in README

## Testing
- `python -m py_compile cleanup.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e43cc2f8832eb10928a925637249